### PR TITLE
Add support for Cocoapods

### DIFF
--- a/Geodesic.podspec
+++ b/Geodesic.podspec
@@ -1,0 +1,120 @@
+#
+#  Be sure to run `pod spec lint Geodesic.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  spec.name         = "Geodesic"
+  spec.version      = "1.0.0"
+  spec.summary      = "CLLocationCoordinate2D` extensions for geodesic calculations."
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  spec.description  = <<-DESC
+  `CLLocationCoordinate2D` extensions for geodesic calculations
+                   DESC
+
+  spec.homepage     = "https://github.com/sbooth/Geodesic.git"
+  # spec.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See https://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  # spec.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+  spec.license      = { :type => "MIT", :file => "LICENSE.txt" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  spec.author             = { "Stephen Booth" => "me@sbooth.org" }
+  spec.social_media_url   = "https://twitter.com/feistydog"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # spec.platform     = :ios
+  # spec.platform     = :ios, "5.0"
+
+  #  When using multiple platforms
+  spec.ios.deployment_target = "13.0"
+  spec.osx.deployment_target = "10.13"
+  # spec.watchos.deployment_target = "2.0"
+  # spec.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  spec.source       = { :git => "https://github.com/sbooth/Geodesic.git", :tag => "#{spec.version}" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  spec.source_files  = "Sources/**/*.swift"
+
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # spec.framework  = "SomeFramework"
+  # spec.frameworks = "SomeFramework", "AnotherFramework"
+
+  # spec.library   = "iconv"
+  # spec.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  # spec.requires_arc = true
+
+  # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  spec.dependency "CGeodesic", "~> 2"
+
+end

--- a/README.md
+++ b/README.md
@@ -2,12 +2,28 @@
 
 `CLLocationCoordinate2D` extensions for geodesic calculations.
 
+## Usage
+
 ```swift
 let lax = CLLocationCoordinate2D(latitude: 33.9424964, longitude: -118.4080486)
 let jfk = CLLocationCoordinate2D(latitude: 40.6399278, longitude: -73.7786925)
 let distance = lax.distanceTo(jfk)
 // distance is approx. 3,982,961 m
 ```
+
+## Cocoapods
+
+This podspec still needs to be merged and published, via:
+https://guides.cocoapods.org/making/making-a-cocoapod.html#release
+
+
+Until then, the Geodesic Swift wrapper needs to know how to find the C-based CGeodesic framework, so you will need to preface the path to that framework as below:
+
+```
+    pod 'CGeodesic', :git => 'https://github.com/sbooth/CGeodesic'
+    pod 'Geodesic', :git => 'https://github.com/sbooth/Geodesic'
+```
+
 ## License
 
 Geodesic is released under the [MIT License](https://github.com/sbooth/Geodesic/blob/main/LICENSE.txt).


### PR DESCRIPTION
I added support for Cocoapods in order to import it into a framework of my own.

I left instructions in the README, so this commit will need an edit to remove the aforementioned instructions after the publish command has been written.